### PR TITLE
Add propagation_policy option to APIObject.delete() method

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -142,8 +142,12 @@ class APIObject:
         self.api.raise_for_status(r)
         self.set_obj(r.json())
 
-    def delete(self):
-        r = self.api.delete(**self.api_kwargs())
+    def delete(self, propagation_policy=None):
+        if propagation_policy:
+            options = {"propagationPolicy": propagation_policy}
+        else:
+            options = {}
+        r = self.api.delete(**self.api_kwargs(data=json.dumps(options)))
         if r.status_code != 404:
             self.api.raise_for_status(r)
 


### PR DESCRIPTION
Regarding https://github.com/hjacobs/kube-janitor/issues/28

As it turned out, the issue was the following.  
When you delete an object of `apps/v1` version, its dependent objects are deleted. But when you delete an object of `extensions/v1beta1`, its dependent objects are orphaned. Here is the ref to docs about this behavior: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy

So, when do this:
```python3
import pykube
from helper import get_kube_api
from pykube.objects import NamespacedAPIObject

api = get_kube_api()

d = type("Deployment", (NamespacedAPIObject,), {
    'version': "extensions/v1beta1",  # <----- HERE
    'endpoint': "deployments",
    'kind': "Deployment"
})

first_deploy = list(d.objects(api, namespace="dev"))[0]

first_deploy.delete()
```
its dependent objects are orphaned.

If you change `version` to `apps/v1` then everything is ok.

Now, Kubernetes API allow you to specify `propagationPolicy` with possible values “Orphan”, “Foreground”, or “Background”. Example:
```console
$ curl -X DELETE localhost:8080/apis/apps/v1/namespaces/default/replicasets/my-repset \
-d '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Background"}' \
-H "Content-Type: application/json"
```

So, I added optional argument `propagation_policy` with default value `None`, so that if someone want to explicitly specify policy they can do that with this flag.