### PR TITLE
Fix GCP support

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -52,7 +52,9 @@ class KubernetesHTTPAdapter(requests.adapters.HTTPAdapter):
     def _auth_gcp(self, request, token, expiry, config):
         original_request = request.copy()
 
-        credentials = google.auth.default()[0]
+        credentials = google.auth.default(
+            scopes=['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/userinfo.email']
+        )[0]
         credentials.token = token
         credentials.expiry = expiry
 
@@ -94,7 +96,7 @@ class KubernetesHTTPAdapter(requests.adapters.HTTPAdapter):
                     jsonpath_installed,
                 ]
                 if not all(dependencies):
-                    raise ImportError("missing dependencies for GCP support (try pip install pykube[gcp]")
+                    raise ImportError("missing dependencies for GCP support (try pip install pykube_ng[gcp]")
                 auth_config = auth_provider.get("config", {})
                 if "cmd-path" in auth_config:
                     output = subprocess.check_output(

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -96,7 +96,7 @@ class KubernetesHTTPAdapter(requests.adapters.HTTPAdapter):
                     jsonpath_installed,
                 ]
                 if not all(dependencies):
-                    raise ImportError("missing dependencies for GCP support (try pip install pykube_ng[gcp]")
+                    raise ImportError("missing dependencies for GCP support (try pip install pykube-ng[gcp]")
                 auth_config = auth_provider.get("config", {})
                 if "cmd-path" in auth_config:
                     output = subprocess.check_output(


### PR DESCRIPTION
Updating the pykube[gcp] notice to pykube_ng[gcp].

Updating the scopes passed to the auth query to avoid the following:

```
Scope has changed from "https://www.googleapis.com/auth/cloud-platform" to "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email openid".
Traceback (most recent call last):
  File "/Users/duffy/projects/kube-janitor/kube_janitor/main.py", line 59, in run_loop
    tiller=tiller
  File "/Users/duffy/projects/kube-janitor/kube_janitor/janitor.py", line 209, in clean_up
    for namespace in Namespace.objects(api):
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/query.py", line 133, in __iter__
    return iter(self.query_cache["objects"])
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/query.py", line 123, in query_cache
    cache["response"] = self.execute().json()
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/query.py", line 107, in execute
    r = self.api.get(**kwargs)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/http.py", line 127, in get
    return self.session.get(*args, **self.get_kwargs(**kwargs))
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/http.py", line 39, in session
    self._session = build_session(self.config, self.gcloud_file)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/session.py", line 23, in build_session
    s = _session_object("gcp", config, gcloud_file)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/session.py", line 47, in _session_object
    return GCPSession(config, gcloud_file).create()
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/session.py", line 118, in create
    self._update_token()
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/pykube/session.py", line 129, in _update_token
    refresh_token=self.credentials.get('refresh_token'))
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/requests_oauthlib/oauth2_session.py", line 374, in refresh_token
    self.token = self._client.parse_request_body_response(r.text, scope=self.scope)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/oauthlib/oauth2/rfc6749/clients/base.py", line 415, in parse_request_body_response
    self.token = parse_token_response(body, scope=scope)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/oauthlib/oauth2/rfc6749/parameters.py", line 425, in parse_token_response
    validate_token_parameters(params)
  File "/Users/duffy/.virtualenvs/default/lib/python3.6/site-packages/oauthlib/oauth2/rfc6749/parameters.py", line 455, in validate_token_parameters
    raise w
Warning: Scope has changed from "https://www.googleapis.com/auth/cloud-platform" to "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email openid".
```