### PR TITLE
Exclude "tests" from packaging and installing as an importable module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     zip_safe=False,
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     install_requires=install_requires,
     extras_require={
         "gcp": [


### PR DESCRIPTION
`tests` is not a package, but it is detected as such (because of `__init__.py`), and is packages, and is installed. Can be seen e.g. in `pip install -v pykube-ng` & `pip uninstall pykube-ng` output:

```
$ pip uninstall pykube-ng
Uninstalling pykube-ng-0.25:
  Would remove:
    /Users/svasilyev/.pyenv/versions/3.7.3/envs/kopf/lib/python3.7/site-packages/pykube/*
    /Users/svasilyev/.pyenv/versions/3.7.3/envs/kopf/lib/python3.7/site-packages/pykube_ng-0.25.dist-info/*
    /Users/svasilyev/.pyenv/versions/3.7.3/envs/kopf/lib/python3.7/site-packages/tests/*
Proceed (y/n)? y
  Successfully uninstalled pykube-ng-0.25
```

This PR excludes this directory from being detected & packaged.