### PR TITLE
Remember the streaming response object in watch-queries

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -157,6 +157,7 @@ class WatchQuery(BaseQuery):
     def __init__(self, *args, **kwargs):
         self.resource_version = kwargs.pop("resource_version", None)
         super(WatchQuery, self).__init__(*args, **kwargs)
+        self._response = None
 
     def object_stream(self):
         params = {"watch": "true"}
@@ -172,6 +173,7 @@ class WatchQuery(BaseQuery):
             kwargs["version"] = self.api_obj_class.version
         r = self.api.get(**kwargs)
         self.api.raise_for_status(r)
+        self._response = r
         WatchEvent = namedtuple("WatchEvent", "type object")
         for line in r.iter_lines():
             we = json.loads(line.decode("utf-8"))
@@ -179,6 +181,10 @@ class WatchQuery(BaseQuery):
 
     def __iter__(self):
         return iter(self.object_stream())
+
+    @property
+    def response(self):
+        return self._response
 
 
 def as_selector(value):

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,40 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from pykube import Pod
+from pykube.query import Query
+
+
+@pytest.fixture
+def api():
+    return MagicMock()
+
+
+def test_watch_response_exists(api):
+    stream = Query(api, Pod).watch()
+    assert hasattr(stream, 'response')
+    assert stream.response is None  # not yet executed
+
+
+def test_watch_response_is_readonly(api):
+    stream = Query(api, Pod).watch()
+    with pytest.raises(AttributeError):
+        stream.response = object()
+
+
+def test_watch_response_is_set_on_iter(api):
+    line1 = json.dumps({'type': 'ADDED', 'object': {}}).encode('utf-8')
+    expected_response = MagicMock()
+    expected_response.iter_lines.return_value = [line1]
+    api.get.return_value = expected_response
+
+    stream = Query(api, Pod).watch()
+    next(iter(stream))
+
+    assert stream.response is expected_response
+
+    assert api.get.call_count == 1
+    assert api.get.call_args_list[0][1]['stream'] is True
+    assert 'watch=true' in api.get.call_args_list[0][1]['url']


### PR DESCRIPTION
**Short story:** 

For a termination of a streaming response from outside, the response object should be exposed from the watch-queries.

**Long story:** 

`pykube` uses the streaming responses of `requests` for watching over the objects. These responses can be cancelled when a chunk/line is yielded to the consumer, and the streaming socket itself is waiting.

However, if a streaming response is in the blocking `read()` operation on a socket, and nothing happens on the stream (i.e. no k8s watch-events), it can remain there for long time — minutes, hours — until some data arrives on the socket. This, in turn, makes the application to hang on exit, holding its pod from restarting, since the thread is not finished until the `read()` call is finished.

There is no easy way to terminate the blocking `read()` operation on a socket, and therefore the watching stream — if it runs in a parallel thread. The only way is a dirty hack with the process signals, which interrupt the I/O operations. See a preview in https://github.com/zalando-incubator/kopf/pull/143. This hack can be done only from the main thread, and therefore is only suitable for the runnable application rather than for a library.



