### PR TITLE
Use ID token if auth type is OIDC

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -120,7 +120,11 @@ class KubernetesHTTPAdapter(requests.adapters.HTTPAdapter):
                         auth_config.get("expiry"),
                         config,
                     )
-            # @@@ support oidc
+            elif auth_provider.get("name") == "oidc":
+                auth_config = auth_provider.get("config", {})
+                # @@@ support token refresh
+                if "id-token" in auth_config:
+                    request.headers["Authorization"] = "Bearer {}".format(auth_config["id-token"])
         elif "client-certificate" in config.user:
             kwargs["cert"] = (
                 config.user["client-certificate"].filename(),

--- a/tests/test_config_with_oidc_auth.yaml
+++ b/tests/test_config_with_oidc_auth.yaml
@@ -1,0 +1,23 @@
+# TODO: Replace with a more realistic example
+current-context: thecluster
+clusters:
+    - name: thecluster
+      cluster: {}
+users:
+    - name: admin
+      user:
+        auth-provider:
+          config:
+            client-id: google
+            client-secret: s3cr3t
+            id-token: some-id-token
+            idp-issuer-url: https://accounts.google.com
+            refresh-token: some-refresh-token
+          name: oidc
+contexts:
+    - name: thecluster
+      context:
+        cluster: thecluster
+        user: admin
+    - name: second
+      context: secondcontext


### PR DESCRIPTION
Simply use the ID token inside the Authentication header for the OIDC case. This helps at least a bit when running locally as long as the ID token is still valid.