### PR TITLE
Add flag to http client to allow for the client to be dryrun

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -160,7 +160,7 @@ class HTTPClient:
     Client for interfacing with the Kubernetes API.
     """
 
-    def __init__(self, config: KubeConfig, timeout: float = DEFAULT_HTTP_TIMEOUT):
+    def __init__(self, config: KubeConfig, timeout: float = DEFAULT_HTTP_TIMEOUT, dry_run: bool = False):
         """
         Creates a new instance of the HTTPClient.
 
@@ -170,6 +170,7 @@ class HTTPClient:
         self.config = config
         self.timeout = timeout
         self.url = self.config.cluster["server"]
+        self.dry_run = dry_run
 
         session = requests.Session()
         session.headers['User-Agent'] = f'pykube-ng/{__version__}'
@@ -242,6 +243,11 @@ class HTTPClient:
         if 'timeout' not in kwargs:
             # apply default HTTP timeout
             kwargs['timeout'] = self.timeout
+        if self.dry_run:
+            # Add http query param for dryRun
+            params = kwargs.get('params', {})
+            params['dryRun'] = 'All'
+            kwargs['params'] = params
         return kwargs
 
     def raise_for_status(self, resp):


### PR DESCRIPTION
This allows you to create an http client that will only make dry run requests. (https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/)

```
>>> import pykube
>>> pod = {'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'name': 'lmassa-test', 'namespace': 'node-maintenance-api'}, 'spec': {'containers': [{'name': 'uname', 'image': 'alpine', 'command': ['sleep', '10000000']}]}}
>>> api_real = pykube.HTTPClient(pykube.KubeConfig.from_file("config"), dry_run=False)
>>> api_dryrun = pykube.HTTPClient(pykube.KubeConfig.from_file("config"), dry_run=True)
>>> 
>>> pykube.Pod(api_dryrun, pod).exists()
False
>>> pykube.Pod(api_dryrun, pod).create()
>>> pykube.Pod(api_dryrun, pod).exists()
False
>>> pykube.Pod(api_real, pod).create()
>>> pykube.Pod(api_real, pod).exists()
True
```