### PR TITLE
fix k8s config user both 'token' and 'client-certificate'  [To support Azure Kubernetes]

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -125,13 +125,14 @@ class KubernetesHTTPAdapter(requests.adapters.HTTPAdapter):
                 # @@@ support token refresh
                 if "id-token" in auth_config:
                     request.headers["Authorization"] = "Bearer {}".format(auth_config["id-token"])
-        elif "client-certificate" in config.user:
+        elif config.user.get("username") and config.user.get("password"):
+            request.prepare_auth((config.user["username"], config.user["password"]))
+
+        if "client-certificate" in config.user:
             kwargs["cert"] = (
                 config.user["client-certificate"].filename(),
                 config.user["client-key"].filename(),
             )
-        elif config.user.get("username") and config.user.get("password"):
-            request.prepare_auth((config.user["username"], config.user["password"]))
 
         # setup certificate verification
 


### PR DESCRIPTION
pykube can't connect azure Kubernetes[AKS], because AKS auth need 'token' and 'client-certificate'.
it look like

```yaml
users:
- name: aks-resource-name
  user:
    client-certificate-data: XXXXXXXXXXXXXXXXXXx
    client-key-data: XXXXXXXXXXXXXXXXXXXX
    token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXx
```