### PR TITLE
Patch subresources via separate API endpoints

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -94,8 +94,9 @@ class APIObject:
         if obj_list:
             kw["url"] = self.endpoint
         else:
+            subresource = kwargs.pop("subresource", None) or ""
             operation = kwargs.pop("operation", "")
-            kw["url"] = op.normpath(op.join(self.endpoint, self.name, operation))
+            kw["url"] = op.normpath(op.join(self.endpoint, self.name, subresource, operation))
         params = kwargs.pop("params", None)
         if params is not None:
             query_string = urlencode(params)
@@ -138,12 +139,13 @@ class APIObject:
             .watch()
         )
 
-    def patch(self, strategic_merge_patch):
+    def patch(self, strategic_merge_patch, *, subresource=None):
         """
         Patch the Kubernetes resource by calling the API with a "strategic merge" patch.
         """
         r = self.api.patch(
             **self.api_kwargs(
+                subresource=subresource,
                 headers={"Content-Type": "application/merge-patch+json"},
                 data=json.dumps(strategic_merge_patch),
             )
@@ -151,12 +153,12 @@ class APIObject:
         self.api.raise_for_status(r)
         self.set_obj(r.json())
 
-    def update(self, is_strategic=True):
+    def update(self, is_strategic=True, *, subresource=None):
         """
         Update the Kubernetes resource by calling the API (patch)
         """
         self.obj = obj_merge(self.obj, self._original_obj, is_strategic)
-        self.patch(self.obj)
+        self.patch(self.obj, subresource=subresource)
 
     def delete(self, propagation_policy: str = None):
         """

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -96,7 +96,9 @@ class APIObject:
         else:
             subresource = kwargs.pop("subresource", None) or ""
             operation = kwargs.pop("operation", "")
-            kw["url"] = op.normpath(op.join(self.endpoint, self.name, subresource, operation))
+            kw["url"] = op.normpath(
+                op.join(self.endpoint, self.name, subresource, operation)
+            )
         params = kwargs.pop("params", None)
         if params is not None:
             query_string = urlencode(params)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -345,9 +345,7 @@ def test_patch_subresource(api, requests_mock):
         rsps.add(
             responses.GET,
             "https://localhost:9443/apis/apps/v1/namespaces/default/deployments",
-            json={
-                "items": [{"metadata": {"name": "deploy-1"}}]
-            },
+            json={"items": [{"metadata": {"name": "deploy-1"}}]},
         )
 
         deployments = list(Deployment.objects(api))
@@ -359,13 +357,10 @@ def test_patch_subresource(api, requests_mock):
         rsps.add(
             responses.PATCH,
             "https://localhost:9443/apis/apps/v1/namespaces/default/deployments/deploy-1/status",
-            json={
-                "metadata": {"name": "deploy-1"},
-                "status": {"field": "field"},
-            },
+            json={"metadata": {"name": "deploy-1"}, "status": {"field": "field"}},
         )
 
-        deploy.patch({"status": {"field": "field"}}, subresource='status')
+        deploy.patch({"status": {"field": "field"}}, subresource="status")
         assert len(rsps.calls) == 2
 
         assert json.loads(rsps.calls[-1].request.body) == {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -338,3 +338,36 @@ def test_resource_list(api, requests_mock):
         )
         resource_list = api.resource_list("example.org/v1")
         assert resource_list == data2
+
+
+def test_patch_subresource(api, requests_mock):
+    with requests_mock as rsps:
+        rsps.add(
+            responses.GET,
+            "https://localhost:9443/apis/apps/v1/namespaces/default/deployments",
+            json={
+                "items": [{"metadata": {"name": "deploy-1"}}]
+            },
+        )
+
+        deployments = list(Deployment.objects(api))
+        assert len(deployments) == 1
+        deploy = deployments[0]
+        assert deploy.name == "deploy-1"
+        assert deploy.namespace == "default"
+
+        rsps.add(
+            responses.PATCH,
+            "https://localhost:9443/apis/apps/v1/namespaces/default/deployments/deploy-1/status",
+            json={
+                "metadata": {"name": "deploy-1"},
+                "status": {"field": "field"},
+            },
+        )
+
+        deploy.patch({"status": {"field": "field"}}, subresource='status')
+        assert len(rsps.calls) == 2
+
+        assert json.loads(rsps.calls[-1].request.body) == {
+            "status": {"field": "field"},
+        }


### PR DESCRIPTION
Kubernetes resources are now advised to have `status` & `replica` as sub-resources — especially since Kubernetes 1.16.

This requires separate PATCH requests to separate endpoints, instead of passing the status as part of the main payload of the PATCH request on the resource's body — it is just ignored there (i.e. not applied to the resource).

With this PR, a kwarg named `subresource=` is added to the object's `.patch()` method. The default is to use the resource' main body, unless explicitly said to patch the sub-resource.

A better way would be to internally analyse the CRD's declaration, and whether some subresources are declared separately or not, and to modify the patching method to send separate API requests if the relevant sub-fields are present in the patch's body. Thos way is much more complex, and potentially implies unexpected heuristic in the API client. 

The explicit way seems more straightforward — leaving the decision on what and how to patch to the developers, who also declare their CRDs with/without sub-resources.

---
For reference, the Kubernetes client implements this as separate patching methods: `v1api. patch_namespaced_pod_status()` instead of `v1api. patch_namespaced_pod()` ([link](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/api/core_v1_api.py))