### PR TITLE
Handle relative paths in kubeconfig

### DIFF
--- a/pykube/config.py
+++ b/pykube/config.py
@@ -130,6 +130,16 @@ class KubeConfig:
         self._current_context = value
 
     @property
+    def kubeconfig_file(self):
+        """
+        Returns the path to kubeconfig file, if it exists
+        """
+        if not hasattr(self, "filename"):
+            return None
+        return self.filename
+
+
+    @property
     def current_context(self):
         if self._current_context is None:
             raise exceptions.PyKubeError(
@@ -148,7 +158,7 @@ class KubeConfig:
                 cs[cr["name"]] = c = copy.deepcopy(cr["cluster"])
                 if "server" not in c:
                     c["server"] = "http://localhost"
-                BytesOrFile.maybe_set(c, "certificate-authority")
+                BytesOrFile.maybe_set(c, "certificate-authority", self.kubeconfig_file)
             self._clusters = cs
         return self._clusters
 
@@ -162,8 +172,8 @@ class KubeConfig:
             if "users" in self.doc:
                 for ur in self.doc["users"]:
                     us[ur["name"]] = u = copy.deepcopy(ur["user"])
-                    BytesOrFile.maybe_set(u, "client-certificate")
-                    BytesOrFile.maybe_set(u, "client-key")
+                    BytesOrFile.maybe_set(u, "client-certificate", self.kubeconfig_file)
+                    BytesOrFile.maybe_set(u, "client-key", self.kubeconfig_file)
             self._users = us
         return self._users
 
@@ -202,10 +212,10 @@ class KubeConfig:
         return self.contexts[self.current_context].get("namespace", "default")
 
     def persist_doc(self):
-        if not hasattr(self, "filename") or not self.filename:
+        if not self.kubeconfig_file:
             # Config was provided as string, not way to persit it
             return
-        with open(self.filename, "w") as f:
+        with open(self.kubeconfig_file, "w") as f:
             yaml.safe_dump(
                 self.doc,
                 f,
@@ -229,16 +239,16 @@ class BytesOrFile:
     """
 
     @classmethod
-    def maybe_set(cls, d, key):
+    def maybe_set(cls, d, key, kubeconfig_file):
         file_key = key
         data_key = "{}-data".format(key)
         if data_key in d:
-            d[file_key] = cls(data=d[data_key])
+            d[file_key] = cls(data=d[data_key], kubeconfig_file=kubeconfig_file)
             del d[data_key]
         elif file_key in d:
-            d[file_key] = cls(filename=d[file_key])
+            d[file_key] = cls(filename=d[file_key], kubeconfig_file=kubeconfig_file)
 
-    def __init__(self, filename=None, data=None):
+    def __init__(self, filename=None, data=None, kubeconfig_file=None):
         """
         Creates a new instance of BytesOrFile.
 
@@ -251,6 +261,17 @@ class BytesOrFile:
         if filename is not None and data is not None:
             raise TypeError("filename or data kwarg must be specified, not both")
         elif filename is not None:
+
+            # If relative path is given, should be made absolute with respect to the directory of the kube config
+            # https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#file-references
+            if not os.path.isabs(filename):
+                if kubeconfig_file:
+                    filename = os.path.join(os.path.dirname(kubeconfig_file), filename)
+                else:
+                    raise exceptions.PyKubeError(
+                        "{} passed as relative path, but cannot determine location of kube config".format(filename)
+                    )
+
             if not os.path.isfile(filename):
                 raise exceptions.PyKubeError(
                     "'{}' file does not exist".format(filename)

--- a/pykube/config.py
+++ b/pykube/config.py
@@ -138,7 +138,6 @@ class KubeConfig:
             return None
         return self.filename
 
-
     @property
     def current_context(self):
         if self._current_context is None:
@@ -269,7 +268,9 @@ class BytesOrFile:
                     filename = os.path.join(os.path.dirname(kubeconfig_file), filename)
                 else:
                     raise exceptions.PyKubeError(
-                        "{} passed as relative path, but cannot determine location of kube config".format(filename)
+                        "{} passed as relative path, but cannot determine location of kube config".format(
+                            filename
+                        )
                     )
 
             if not os.path.isfile(filename):


### PR DESCRIPTION
Addresses: https://github.com/kelproject/pykube/issues/130 from the original project.

Per k8s documentation (https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#file-references), if a relative path is specified in kube config, it should be resolved relative to the kubeconfig file, not (as is currently implemented) from the cwd.

Before:
```
luke@Lukes-MacBook-Air pykube % git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
luke@Lukes-MacBook-Air pykube % python3 -c 'import pykube; pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))'                     
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/luke/work/pykube/pykube/http.py", line 204, in __init__
    self.url = self.config.cluster["server"]
  File "/Users/luke/work/pykube/pykube/config.py", line 188, in cluster
    return self.clusters[self.contexts[self.current_context]["cluster"]]
  File "/Users/luke/work/pykube/pykube/config.py", line 151, in clusters
    BytesOrFile.maybe_set(c, "certificate-authority")
  File "/Users/luke/work/pykube/pykube/config.py", line 239, in maybe_set
    d[file_key] = cls(filename=d[file_key])
  File "/Users/luke/work/pykube/pykube/config.py", line 256, in __init__
    "'{}' file does not exist".format(filename)
pykube.exceptions.PyKubeError: 'certs/ndmad1-ca.pem' file does not exist
luke@Lukes-MacBook-Air pykube % python3 -c 'import pykube,os; os.chdir("/Users/luke/.kube"); pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))'
luke@Lukes-MacBook-Air pykube % 
```
After
```
luke@Lukes-MacBook-Air pykube % git checkout handle_relative_paths_in_kubeconfig
Switched to branch 'handle_relative_paths_in_kubeconfig'
luke@Lukes-MacBook-Air pykube % python3 -c 'import pykube; pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))'                                  
luke@Lukes-MacBook-Air pykube % python3 -c 'import pykube,os; os.chdir("/Users/luke/.kube"); pykube.HTTPClient(pykube.KubeConfig.from_file("~/.kube/config"))'
luke@Lukes-MacBook-Air pykube % 
```

Note that if PykubeConfig is created via a serviceaccount, there is no change to behavior (since there is no kubeconfig file to find)
```
luke@Lukes-MacBook-Air pykube % kubectl -n sandbox run --generator=run-pod/v1 --limits=cpu=200m,memory=512Mi -it hello-world-$USER --image techops-docker.maven.dev.tripadvisor.com/utils/pykube-upstream-tester:0.1 -- /bin/sh
If you don't see a command prompt, try pressing enter.
/ # python3 -c 'import pykube; pykube.HTTPClient(pykube.KubeConfig.from_service_account())'
/ #
```