### PR TITLE
Fix Windows paths by using posixpath for URL building 

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import os.path as op
 import posixpath
 from inspect import getmro
 from typing import Optional

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os.path as op
+import posixpath
 from inspect import getmro
 from typing import Optional
 from typing import Type
@@ -95,7 +96,7 @@ class APIObject:
             kw["url"] = self.endpoint
         else:
             operation = kwargs.pop("operation", "")
-            kw["url"] = op.normpath(op.join(self.endpoint, self.name, operation))
+            kw["url"] = posixpath.join(self.endpoint, self.name, operation)
         params = kwargs.pop("params", None)
         if params is not None:
             query_string = urlencode(params)


### PR DESCRIPTION
This PR fixes a bug in Windows where api_kwargs builds an invalid URL.

#57 