### PR TITLE
update API versions for Kubernetes 1.18

### DIFF
--- a/pykube/__init__.py
+++ b/pykube/__init__.py
@@ -34,7 +34,6 @@ from .objects import (  # noqa: F401
     Service,
     ServiceAccount,
     StatefulSet,
-    ThirdPartyResource,
     Role,
     ClusterRole,
     RoleBinding,

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -327,13 +327,6 @@ class Ingress(NamespacedAPIObject):
     kind = "Ingress"
 
 
-class ThirdPartyResource(APIObject):
-
-    version = "extensions/v1beta1"
-    endpoint = "thirdpartyresources"
-    kind = "ThirdPartyResource"
-
-
 class Job(NamespacedAPIObject, ScalableMixin):
 
     version = "batch/v1"
@@ -549,6 +542,6 @@ class PodDisruptionBudget(NamespacedAPIObject):
 
 class CustomResourceDefinition(APIObject):
 
-    version = "apiextensions.k8s.io/v1beta1"
+    version = "apiextensions.k8s.io/v1"
     endpoint = "customresourcedefinitions"
     kind = "CustomResourceDefinition"


### PR DESCRIPTION
Update resource types and API versions for Kubernetes v1.18.

* https://kube-web-view.demo.j-serv.de/clusters/local/namespaces/default/_resource-types
* https://kube-web-view.demo.j-serv.de/clusters/local/_resource-types