### PR TITLE
Read default namespace from service account

### DIFF
--- a/pykube/config.py
+++ b/pykube/config.py
@@ -32,9 +32,12 @@ class KubeConfig:
         """
         Construct KubeConfig from in-cluster service account.
         """
+        with open(os.path.join(path, "namespace")) as fp:
+            namespace = fp.read()
 
         with open(os.path.join(path, "token")) as fp:
             token = fp.read()
+
         host = os.environ.get("PYKUBE_KUBERNETES_SERVICE_HOST")
         if host is None:
             host = os.environ["KUBERNETES_SERVICE_HOST"]
@@ -53,7 +56,14 @@ class KubeConfig:
             ],
             "users": [{"name": "self", "user": {"token": token}}],
             "contexts": [
-                {"name": "self", "context": {"cluster": "self", "user": "self"}}
+                {
+                    "name": "self",
+                    "context": {
+                        "cluster": "self",
+                        "user": "self",
+                        "namespace": namespace,
+                    },
+                }
             ],
             "current-context": "self",
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,9 +23,13 @@ def test_from_service_account_no_file(tmpdir):
         config.KubeConfig.from_service_account(path=str(tmpdir))
 
 
-def test_from_service_account_(tmpdir):
+def test_from_service_account(tmpdir):
+    namespace_file = Path(tmpdir) / "namespace"
     token_file = Path(tmpdir) / "token"
     ca_file = Path(tmpdir) / "ca.crt"
+
+    with namespace_file.open("w") as fd:
+        fd.write("mynamespace")
 
     with token_file.open("w") as fd:
         fd.write("mytok")
@@ -43,6 +47,7 @@ def test_from_service_account_(tmpdir):
         "certificate-authority": str(ca_file),
     }
     assert cfg.doc["users"][0]["user"]["token"] == "mytok"
+    assert cfg.namespace == "mynamespace"
 
 
 def test_from_url():


### PR DESCRIPTION
This reads default namespace which have to be used for all namespaced operations from `/var/run/secrets/kubernetes.io/serviceaccount/namespace` and configures context with it.