### PR TITLE
add mpijob

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -334,6 +334,10 @@ class Job(NamespacedAPIObject, ScalableMixin):
     def parallelism(self, value):
         self.obj["spec"]["parallelism"] = value
 
+class MPIJob(NamespacedAPIObject):
+    version = "kubeflow.org/v1alpha2"
+    endpoint = "mpijobs"
+    kind = "MPIJob"
 
 class Namespace(APIObject):
     version = "v1"


### PR DESCRIPTION
When i prepare to create MPIJob, i find there is not MPIJob resource, so i add the mpijob resource, just in `objects.py`